### PR TITLE
Split buffer-filling and fft

### DIFF
--- a/src/ofxBeat.cpp
+++ b/src/ofxBeat.cpp
@@ -151,8 +151,16 @@ void ofxBeat::update(int _t) {
   updateBand(isHat(), HIHAT_BAND, _t);
 }
 
-void ofxBeat::audioReceived(float* input, int bufferSize, int nChannels) {
+void ofxBeat::audioReceived(const float* const input, int bufferSize, int nChannels) {
+    audioFill(input, bufferSize);
+    audioProcess(bufferSize);
+}
+
+void ofxBeat::audioFill(const float* const input, int bufferSize) {
   memcpy(audio_input, input, sizeof(float) * bufferSize);
+}
+
+void ofxBeat::audioProcess(int bufferSize) {
   float avg_power = 0.0f;
   myfft.powerSpectrum(0, (int)fft_size, audio_input, buffer_size, magnitude, phase, power, &avg_power);
   

--- a/src/ofxBeat.h
+++ b/src/ofxBeat.h
@@ -64,7 +64,9 @@ public:
   void setBeatValue(float bv) {beatValue = bv;}
 
   void update(int);
-  void audioReceived(float*, int, int);
+  void audioReceived(const float *const, int, int);
+  void audioFill(const float *const, int);
+  void audioProcess(int);
 
   float kick();
   float snare();


### PR DESCRIPTION
This enables us to release any lock earlier in a multi-threaded
environment

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>